### PR TITLE
Fix for issue #370: "Byregot stack efficency is calculated as a buff,…

### DIFF
--- a/app/js/ffxivcraftmodel.js
+++ b/app/js/ffxivcraftmodel.js
@@ -324,21 +324,21 @@ function ApplyModifiers(s, action, condition) {
     // Effects modifying quality increase multiplier
     var qualityIncreaseMultiplier = 1;
 
-    // We can only use Byregot actions when we have at least 2 stacks of inner quiet
-    if (isActionEq(action, AllActions.byregotsBlessing)) {
-        if ((AllActions.innerQuiet.shortName in s.effects.countUps) && s.effects.countUps[AllActions.innerQuiet.shortName] >= 1) {
-            qualityIncreaseMultiplier += 0.2 * s.effects.countUps[AllActions.innerQuiet.shortName];
-        } else {
-            qualityIncreaseMultiplier = 0;
-        }
-    }
-
     if ((AllActions.greatStrides.shortName in s.effects.countDowns) && (qualityIncreaseMultiplier > 0)) {
         qualityIncreaseMultiplier += 1;
     }
 
     if (AllActions.innovation.shortName in s.effects.countDowns) {
         qualityIncreaseMultiplier += 0.2;
+    }
+
+    // We can only use Byregot actions when we have at least 2 stacks of inner quiet
+    if (isActionEq(action, AllActions.byregotsBlessing)) {
+        if ((AllActions.innerQuiet.shortName in s.effects.countUps) && s.effects.countUps[AllActions.innerQuiet.shortName] >= 1) {
+            qualityIncreaseMultiplier *= 1 + (0.2 * s.effects.countUps[AllActions.innerQuiet.shortName]);
+        } else {
+            qualityIncreaseMultiplier = 0;
+        }
     }
 
     // Calculate base and modified progress gain


### PR DESCRIPTION
… not base efficency (quality error)"

Issue caused by applying Byregot's Blessing stack bonus as an additive modifier (like GS and Innovation are) instead of a multiplicative modifier (like touches are). Fix involved changing BB's effect on the quality multiplier to be multiplicative and moving it to occur after GS and Innovation are taken into account.

This fix has the added effect of setting the quality multiplier to zero when BB is used without sufficient IQ stacks even when under the effects of Innovation.